### PR TITLE
getSass should always return a Promise

### DIFF
--- a/main.js
+++ b/main.js
@@ -63,7 +63,7 @@ var getSass = (function(){
       return Promise.resolve(loader.locate({ name: name }));
     }).then(function(url){
       var sass = new Sass(url);
-      getSass = function() { return sass; };
+      getSass = function() { return Promise.resolve(sass); };
       return sass;
     });
   };

--- a/test/another.scss
+++ b/test/another.scss
@@ -1,0 +1,3 @@
+body {
+  font-weight: bold;
+}

--- a/test/main.js
+++ b/test/main.js
@@ -1,1 +1,2 @@
 import 'test/style.scss!';
+import 'test/another.scss!';

--- a/test/test.js
+++ b/test/test.js
@@ -11,4 +11,5 @@ QUnit.module("steal-sass", {
 
 QUnit.test("basics works", function(){
   F("style").exists("the style was added to the page");
+  F("style").size(2, "there are two styles on the page");
 });


### PR DESCRIPTION
Fixes #3

In order to get a Sass object that can be instantiated we first have to
look up whether the web worker is located. To do this the `getSass`
function was created. After it has done the work the first time getSass
simply returns the same sass object. However the use of getSass expects
it to return a Promise, which means it will start throwing after the 2nd
scss file is imported. The fix is simply to always resolve getSass with
a Promise.resolve call.
