### PR TITLE
fix the compiling issue

### DIFF
--- a/nodesass.js
+++ b/nodesass.js
@@ -1,4 +1,14 @@
 var loader = require("@loader");
-// if we build your app with steal-tools, we are currently not in the steal-sass directory
+var sassSync = "sass.js/dist/sass.sync.js";
+
+// if we are on npm2 and we build your app with steal-tools, we are currently not in the
+// steal-sass directory.
 // we have to set the fully qualified path to the module
-module.exports = loader._nodeRequire(__dirname + "/node_modules/sass.js/dist/sass.sync.js");
+var sassLocation = __dirname + "/node_modules/" + sassSync;
+
+try {
+	// try to resolve the sass module on npm3
+	sassLocation = loader._nodeRequire.resolve(sassSync);
+} catch (e) {}
+
+module.exports = loader._nodeRequire(sassLocation);

--- a/nodesass.js
+++ b/nodesass.js
@@ -1,2 +1,4 @@
 var loader = require("@loader");
-module.exports = loader._nodeRequire("sass.js");
+// if we build your app with steal-tools, we are currently not in the steal-sass directory
+// we have to set the fully qualified path to the module
+module.exports = loader._nodeRequire(__dirname + "/node_modules/sass.js/dist/sass.sync.js");

--- a/package.json
+++ b/package.json
@@ -30,22 +30,22 @@
     "envs": {
       "build": {
         "map": {
-          "$sass.js": "nodesass"
+          "$sass.js": "steal-sass/nodesass"
         }
       },
       "build-development": {
         "map": {
-          "$sass.js": "nodesass"
+          "$sass.js": "steal-sass/nodesass"
         }
       },
       "server-development": {
         "map": {
-          "$sass.js": "nodesass"
+          "$sass.js": "steal-sass/nodesass"
         }
       },
       "server-production": {
         "map": {
-          "$sass.js": "nodesass"
+          "$sass.js": "steal-sass/nodesass"
         }
       }
     },


### PR DESCRIPTION
fix #5 

set the fully qualified path to the sass.js module.
if we make a build, we a currently not at the `sass-steal` working directory.
so node doesn't find the module. node will look at the root
for example:
`/node_module/sass.js`
but node should look into
`/node_modules/steal-sass/`

@matthewp look at the PR and give me some feedback
